### PR TITLE
Open libGL.so.1 instead of libGL.so on unixoids.

### DIFF
--- a/glfw_base.lua
+++ b/glfw_base.lua
@@ -14,7 +14,7 @@ if ffi.os == "Windows" then
 	glu = ffi.load("glu32")
 	glfw = ffi.load("glfw3")
 else
-	gl = ffi.load("GL")
+	gl = ffi.load("GL.so.1")
 	glu = ffi.load("GLU")
 	glfw = ffi.load("glfw.so.3")
 end


### PR DESCRIPTION
This is what SDL and GLFW itself do, and is debatably the preferred form according to the unclear official ABI recommendations.

This stops (for example) the mesa / unaccelerated libs being loaded on machines with nvidia drivers etc.
